### PR TITLE
support synchronous `put` operation

### DIFF
--- a/source/java/src/lucee/extension/io/cache/redis/NearCacheEntry.java
+++ b/source/java/src/lucee/extension/io/cache/redis/NearCacheEntry.java
@@ -19,7 +19,7 @@ public class NearCacheEntry implements CacheEntry {
 
 	/**
 	 * Some optional callback to be performed immediately after the write to cache is complete.
-	 * Can be null, meaning "so such action".
+	 * Can be null, meaning "there is no callback to run".
 	 */
 	public final Runnable onComplete;
 

--- a/source/java/src/lucee/extension/io/cache/redis/NearCacheEntry.java
+++ b/source/java/src/lucee/extension/io/cache/redis/NearCacheEntry.java
@@ -17,12 +17,27 @@ public class NearCacheEntry implements CacheEntry {
 	private byte[] serialized;
 	private long count;
 
+	/**
+	 * Some optional callback to be performed immediately after the write to cache is complete.
+	 * Can be null, meaning "so such action".
+	 */
+	public final Runnable onComplete;
+
 	public NearCacheEntry(byte[] key, Object val, int exp, long count) {
 		this.key = key;
 		this.val = val;
 		this.exp = exp;
 		this.created = System.currentTimeMillis();
 		this.count = count;
+		this.onComplete = null;
+	}
+	public NearCacheEntry(byte[] key, Object val, int exp, long count, Runnable onComplete) {
+		this.key = key;
+		this.val = val;
+		this.exp = exp;
+		this.created = System.currentTimeMillis();
+		this.count = count;
+		this.onComplete = onComplete;
 	}
 
 	@Override

--- a/source/java/src/lucee/extension/io/cache/redis/RedisCache.java
+++ b/source/java/src/lucee/extension/io/cache/redis/RedisCache.java
@@ -147,10 +147,10 @@ public class RedisCache extends CacheSupport implements Command {
 
 		//
 		// "default" behavior is async
-		// If config's "synchronous" value is missing or is explicitly false, we'll get async=true;
-		// otherwise, "synchronous" was passed and was cftruthy, and we'll get async=false
+		// If config's "synchronousPut" value is missing or is explicitly false, we'll get async=true;
+		// otherwise, "synchronousPut" was passed and was cftruthy, and we'll get async=false
 		//
-		final boolean synchronous = caster.toBooleanValue(arguments.get("synchronous", null), false);
+		final boolean synchronous = caster.toBooleanValue(arguments.get("synchronousPut", null), false);
 		async = !synchronous;
 
 		String logName = caster.toString(arguments.get("log", null), null);


### PR DESCRIPTION
To fix #13, this enables a "synchronous" mode for the put operation. A configuration can now look like:

```
this.cache.connections[ "x" ] = {
	class : 'lucee.extension.io.cache.redis.simple.RedisCache',
	bundleName : 'redis.extension',
	bundleVersion : '3.0.0.<x>',
	storage : true,
	custom : {
		"password" : "",
		"port" : "1234",
		...
		"synchronousPut": true,
	}
};
```

Very high confidence this fixes the reported race condition, but I haven't done any performance regression testing to see how this pans out in the real world. However, the new option is entirely opt-in, so any regressions would be new behavior that people have to sign up for via configuration.
